### PR TITLE
Add 惠首尔(huiseoul) to showcase

### DIFF
--- a/website/src/react-native/showcase.js
+++ b/website/src/react-native/showcase.js
@@ -322,6 +322,13 @@ var featured = [
     infoLink: 'https://artsy.github.io/series/react-native-at-artsy/',
     infoTitle: 'React Native at Artsy',
   },
+  {
+    name: '惠首尔- 你的私人美肤顾问 韩国化妆品海淘直邮',
+    icon: 'https://cdn.huiseoul.com/icon.png',
+    linkAppStore: 'https://itunes.apple.com/us/app/hui-shou-er-ni-si-ren-mei/id1127150360?ls=1&mt=8',
+    infoLink: 'https://engineering.huiseoul.com/building-a-conversational-e-commerce-app-in-6-weeks-with-react-native-c35d46637e07',
+    infoTitle: 'Building a conversational E-commerce app in 6 weeks with React Native',
+  },
 ];
 
 featured.sort(function(a, b) {


### PR DESCRIPTION
> It also must be useful considering that the majority
of readers only speak English. So, each app in the showcase should link to either:
1/ An English-language news article discussing the app, built either by a funded startup or for a public company
2/ An English-language technical post on a funded startup or public company blog discussing React Native
For each app in the showcase, use infoLink and infoTitle to reference this content.

- We wrote a technical post on [medium](https://engineering.huiseoul.com/building-a-conversational-e-commerce-app-in-6-weeks-with-react-native-c35d46637e07#.776ll9ram)
- We also funded, reference [#1](http://besuccess.com/2015/08/huiseoul/), [#2](https://www.crunchbase.com/organization/trillionaire#/entity)